### PR TITLE
Update dashboard layout

### DIFF
--- a/components/pages/dashboard.tsx
+++ b/components/pages/dashboard.tsx
@@ -34,10 +34,14 @@ export function Dashboard() {
           <MentionsFeed />
         </div>
 
-        {/* Center Column - Charts */}
-        <div className="lg:col-span-1 space-y-6">
-          <MentionVolumeChart />
-          <PlatformDistribution />
+        {/* Right Columns - Charts */}
+        <div className="lg:col-span-2 grid grid-cols-1 lg:grid-cols-3 gap-6">
+          <div className="lg:col-span-2">
+            <MentionVolumeChart />
+          </div>
+          <div className="lg:col-span-1">
+            <PlatformDistribution />
+          </div>
         </div>
 
       </div>


### PR DESCRIPTION
## Summary
- arrange dashboard charts so Platform Distribution sits to the right of Mention Volume Timeline

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6853036991dc8327aa3b66215a1c5d77