### PR TITLE
Remove new highlight from product intelligence tab

### DIFF
--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -21,7 +21,7 @@ import { Separator } from '@/components/ui/separator';
 const navigationItems = [
   { id: 'dashboard', label: 'Dashboard', icon: Home, badge: null },
   { id: 'monitoring', label: 'Brand Monitoring', icon: Eye, badge: '2.8k' },
-  { id: 'products', label: 'Product Intelligence', icon: BarChart3, badge: null, highlight: true },
+  { id: 'products', label: 'Product Intelligence', icon: BarChart3, badge: null },
   { id: 'reports', label: 'Reports', icon: FileText, badge: '3' },
   { id: 'settings', label: 'Settings', icon: Settings, badge: null }
 ];


### PR DESCRIPTION
## Summary
- remove highlight attribute from Product Intelligence navigation item

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685303cf3c848327aec498234029457c