### PR TITLE
Fix Platform Performance card overflow

### DIFF
--- a/components/product-intelligence/platform-performance.tsx
+++ b/components/product-intelligence/platform-performance.tsx
@@ -34,7 +34,8 @@ export function PlatformPerformance() {
       animate={{ opacity: 1, y: 0 }}
       transition={{ delay: 0.2 }}
     >
-      <Card className="h-[500px]">
+      {/* Allow the card to grow so the footer content isn't cut off */}
+      <Card className="min-h-[500px]">
         <CardHeader>
           <CardTitle className="flex items-center space-x-2">
             <Smartphone className="w-5 h-5 text-purple-600" />


### PR DESCRIPTION
## Summary
- expand Platform Performance card height to fit all content

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6853071cd0808327be8843060e5a6374