### PR TITLE
Clean sample data

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,7 +13,7 @@ const pageComponents = {
   monitoring: BrandMonitoring,
   products: ProductIntelligence,
   setup: CampaignSetup,
-  reports: () => <div className="p-6"><h1 className="text-2xl font-bold">Reports - Coming Soon</h1></div>,
+  reports: () => <div className="p-6"><h1 className="text-2xl font-bold">Reports</h1></div>,
   settings: () => <div className="p-6"><h1 className="text-2xl font-bold">Settings - Coming Soon</h1></div>,
 };
 

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -20,9 +20,9 @@ import { Separator } from '@/components/ui/separator';
 
 const navigationItems = [
   { id: 'dashboard', label: 'Dashboard', icon: Home, badge: null },
-  { id: 'monitoring', label: 'Brand Monitoring', icon: Eye, badge: '2.8k' },
+  { id: 'monitoring', label: 'Brand Monitoring', icon: Eye, badge: null },
   { id: 'products', label: 'Product Intelligence', icon: BarChart3, badge: null },
-  { id: 'reports', label: 'Reports', icon: FileText, badge: '3' },
+  { id: 'reports', label: 'Reports', icon: FileText, badge: null },
   { id: 'settings', label: 'Settings', icon: Settings, badge: null }
 ];
 

--- a/components/product-intelligence/customer-journey.tsx
+++ b/components/product-intelligence/customer-journey.tsx
@@ -95,48 +95,6 @@ export function CustomerJourney() {
             </div>
           </div>
 
-          {/* Stage Insights */}
-          <div className="grid grid-cols-2 gap-4">
-            <div className="space-y-2">
-              <h4 className="text-sm font-medium">Top Converting Stages</h4>
-              <div className="space-y-1">
-                <div className="flex items-center justify-between text-sm">
-                  <span>Awareness → Consideration</span>
-                  <Badge variant="secondary">60%</Badge>
-                </div>
-                <div className="flex items-center justify-between text-sm">
-                  <span>Experience → Advocacy</span>
-                  <Badge variant="secondary">49%</Badge>
-                </div>
-              </div>
-            </div>
-            <div className="space-y-2">
-              <h4 className="text-sm font-medium">Biggest Drop-offs</h4>
-              <div className="space-y-1">
-                <div className="flex items-center justify-between text-sm">
-                  <span>Consideration → Purchase</span>
-                  <Badge variant="destructive">40%</Badge>
-                </div>
-                <div className="flex items-center justify-between text-sm">
-                  <span>Purchase → Experience</span>
-                  <Badge variant="destructive">19%</Badge>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          {/* Journey Insights */}
-          <div className="bg-indigo-50 dark:bg-indigo-950/20 p-3 rounded-lg border border-indigo-200 dark:border-indigo-800">
-            <h4 className="text-sm font-medium text-indigo-800 dark:text-indigo-200 mb-2">
-              Journey Insights
-            </h4>
-            <ul className="text-xs text-indigo-700 dark:text-indigo-300 space-y-1">
-              <li>• Strong awareness-to-consideration conversion (60%)</li>
-              <li>• Purchase intent needs improvement (36% conversion)</li>
-              <li>• High advocacy rate among customers (14% share experiences)</li>
-              <li>• Focus on reducing consideration-to-purchase friction</li>
-            </ul>
-          </div>
         </CardContent>
       </Card>
     </motion.div>

--- a/components/product-intelligence/mention-volume-timeline.tsx
+++ b/components/product-intelligence/mention-volume-timeline.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Brush, ReferenceLine } from 'recharts';
+import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Brush } from 'recharts';
 import { TrendingUp, MessageSquare, Zap } from 'lucide-react';
 import { productIntelligenceData } from '@/lib/sample-data';
 import { motion } from 'framer-motion';
@@ -38,16 +38,6 @@ export function MentionVolumeTimeline() {
                 Negative
               </Button>
             </div>
-          </div>
-          <div className="flex items-center space-x-4 text-sm text-gray-600 dark:text-gray-400">
-            <div className="flex items-center space-x-1">
-              <Zap className="w-4 h-4" />
-              <span>Peak: March 15 (Product Launch)</span>
-            </div>
-            <span>•</span>
-            <span>Avg. Daily: 52 mentions</span>
-            <span>•</span>
-            <span>Growth: +45% vs last period</span>
           </div>
         </CardHeader>
         <CardContent>
@@ -113,7 +103,6 @@ export function MentionVolumeTimeline() {
                 fill="url(#negative)"
                 strokeWidth={2}
               />
-              <ReferenceLine x="03/15" stroke="#2563eb" strokeDasharray="5 5" />
               <Brush dataKey="date" height={30} stroke="#2563eb" />
             </AreaChart>
           </ResponsiveContainer>

--- a/components/product-intelligence/platform-performance.tsx
+++ b/components/product-intelligence/platform-performance.tsx
@@ -81,27 +81,6 @@ export function PlatformPerformance() {
             </BarChart>
           </ResponsiveContainer>
           
-          {/* Platform Insights */}
-          <div className="mt-4 space-y-2">
-            <div className="flex items-center justify-between text-sm">
-              <span className="text-gray-600 dark:text-gray-400">Top Performing Platform:</span>
-              <Badge className="bg-blue-100 text-blue-800">
-                Twitter - {topMentions.toLocaleString()} mentions
-              </Badge>
-            </div>
-            <div className="flex items-center justify-between text-sm">
-              <span className="text-gray-600 dark:text-gray-400">Highest Engagement:</span>
-              <Badge className="bg-purple-100 text-purple-800">
-                TikTok - {highestEngagement}% avg.
-              </Badge>
-            </div>
-            <div className="flex items-center justify-between text-sm">
-              <span className="text-gray-600 dark:text-gray-400">Best Sentiment:</span>
-              <Badge className="bg-green-100 text-green-800">
-                Instagram - {bestSentiment.toFixed(0)}%
-              </Badge>
-            </div>
-          </div>
         </CardContent>
       </Card>
     </motion.div>

--- a/components/product-intelligence/sentiment-analysis.tsx
+++ b/components/product-intelligence/sentiment-analysis.tsx
@@ -7,30 +7,14 @@ import { PieChart, Pie, Cell, ResponsiveContainer, LineChart, Line, XAxis, YAxis
 import { Heart, Frown, Meh, TrendingUp } from 'lucide-react';
 import { motion } from 'framer-motion';
 
-const sentimentData = [
-  { name: 'Positive', value: 62, color: '#10b981' },
-  { name: 'Neutral', value: 25, color: '#6b7280' },
-  { name: 'Negative', value: 13, color: '#ef4444' }
-];
+const sentimentData: { name: string; value: number; color: string }[] = [];
 
-const sentimentTrend = [
-  { date: '1', score: 72 },
-  { date: '7', score: 68 },
-  { date: '14', score: 71 },
-  { date: '21', score: 76 },
-  { date: '28', score: 78 }
-];
+const sentimentTrend: { date: string; score: number }[] = [];
 
-const topSentimentDrivers = [
-  { type: 'positive', keyword: 'amazing camera', count: 89 },
-  { type: 'positive', keyword: 'great design', count: 67 },
-  { type: 'positive', keyword: 'fast performance', count: 54 },
-  { type: 'negative', keyword: 'battery drain', count: 43 },
-  { type: 'negative', keyword: 'overheating', count: 28 }
-];
+const topSentimentDrivers: { type: 'positive' | 'negative'; keyword: string; count: number }[] = [];
 
 export function SentimentAnalysis() {
-  const overallScore = 78;
+  const overallScore = 0;
 
   return (
     <motion.div
@@ -52,10 +36,6 @@ export function SentimentAnalysis() {
               <span className="text-2xl font-bold text-white">{overallScore}</span>
             </div>
             <p className="text-sm text-gray-600 dark:text-gray-400">Overall Sentiment Score</p>
-            <div className="flex items-center justify-center space-x-1 mt-1">
-              <TrendingUp className="w-4 h-4 text-green-600" />
-              <span className="text-sm text-green-600">+5% vs last period</span>
-            </div>
           </div>
 
           {/* Sentiment Breakdown */}


### PR DESCRIPTION
## Summary
- remove placeholder analytics data for product sentiment and timelines
- strip sample insights from product journey and performance pages
- drop badges with dummy counts from the sidebar
- simplify the reports placeholder page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6853098160688327af3ec5a055f8723e