### PR TITLE
Add campaign selection and reports filtering

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,11 +5,12 @@ import { useAppStore } from '@/lib/store';
 import { MainLayout } from '@/components/layout/main-layout';
 import { Dashboard } from '@/components/pages/dashboard';
 import { CampaignSetup } from '@/components/pages/campaign-setup';
+import { Reports } from '@/components/pages/reports';
 
 const pageComponents = {
   dashboard: Dashboard,
   setup: CampaignSetup,
-  reports: () => <div className="p-6"><h1 className="text-2xl font-bold">Reports</h1></div>,
+  reports: Reports,
   settings: () => <div className="p-6"><h1 className="text-2xl font-bold">Settings - Coming Soon</h1></div>,
 };
 

--- a/components/dashboard/charts/mention-volume-chart.tsx
+++ b/components/dashboard/charts/mention-volume-chart.tsx
@@ -3,14 +3,28 @@
 import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Brush } from 'recharts';
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Brush,
+} from 'recharts';
 import { Download, TrendingUp } from 'lucide-react';
 import { generateTimeSeriesData } from '@/lib/sample-data';
+import { useAppStore } from '@/lib/store';
 import { motion } from 'framer-motion';
 
-const data = generateTimeSeriesData(30);
-
 export function MentionVolumeChart() {
+  const { selectedBrand } = useAppStore();
+  const data = React.useMemo(
+    () => generateTimeSeriesData(selectedBrand || 'brand1', 30),
+    [selectedBrand]
+  );
+
   return (
     <motion.div
       initial={{ opacity: 0, y: 20 }}
@@ -45,22 +59,22 @@ export function MentionVolumeChart() {
             <AreaChart data={data} margin={{ top: 10, right: 30, left: 0, bottom: 0 }}>
               <defs>
                 <linearGradient id="positive" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="5%" stopColor="#10b981" stopOpacity={0.8}/>
-                  <stop offset="95%" stopColor="#10b981" stopOpacity={0.1}/>
+                  <stop offset="5%" stopColor="#10b981" stopOpacity={0.8} />
+                  <stop offset="95%" stopColor="#10b981" stopOpacity={0.1} />
                 </linearGradient>
                 <linearGradient id="negative" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="5%" stopColor="#ef4444" stopOpacity={0.8}/>
-                  <stop offset="95%" stopColor="#ef4444" stopOpacity={0.1}/>
+                  <stop offset="5%" stopColor="#ef4444" stopOpacity={0.8} />
+                  <stop offset="95%" stopColor="#ef4444" stopOpacity={0.1} />
                 </linearGradient>
                 <linearGradient id="neutral" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="5%" stopColor="#6b7280" stopOpacity={0.8}/>
-                  <stop offset="95%" stopColor="#6b7280" stopOpacity={0.1}/>
+                  <stop offset="5%" stopColor="#6b7280" stopOpacity={0.8} />
+                  <stop offset="95%" stopColor="#6b7280" stopOpacity={0.1} />
                 </linearGradient>
               </defs>
               <CartesianGrid strokeDasharray="3 3" />
               <XAxis dataKey="date" />
               <YAxis />
-              <Tooltip 
+              <Tooltip
                 content={({ active, payload, label }) => {
                   if (active && payload && payload.length) {
                     return (
@@ -77,27 +91,9 @@ export function MentionVolumeChart() {
                   return null;
                 }}
               />
-              <Area
-                type="monotone"
-                dataKey="positive"
-                stackId="1"
-                stroke="#10b981"
-                fill="url(#positive)"
-              />
-              <Area
-                type="monotone"
-                dataKey="neutral"
-                stackId="1"
-                stroke="#6b7280"
-                fill="url(#neutral)"
-              />
-              <Area
-                type="monotone"
-                dataKey="negative"
-                stackId="1"
-                stroke="#ef4444"
-                fill="url(#negative)"
-              />
+              <Area type="monotone" dataKey="positive" stackId="1" stroke="#10b981" fill="url(#positive)" />
+              <Area type="monotone" dataKey="neutral" stackId="1" stroke="#6b7280" fill="url(#neutral)" />
+              <Area type="monotone" dataKey="negative" stackId="1" stroke="#ef4444" fill="url(#negative)" />
               <Brush dataKey="date" height={30} stroke="#8884d8" />
             </AreaChart>
           </ResponsiveContainer>

--- a/components/dashboard/charts/platform-distribution.tsx
+++ b/components/dashboard/charts/platform-distribution.tsx
@@ -4,11 +4,14 @@ import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { PieChart, Pie, Cell, ResponsiveContainer, Legend, Tooltip } from 'recharts';
 import { platformData } from '@/lib/sample-data';
+import { useAppStore } from '@/lib/store';
 import { motion } from 'framer-motion';
 
 const COLORS = ['#1DA1F2', '#E4405F', '#1877F2', '#000000', '#0A66C2', '#FF0000', '#FF4500'];
 
 export function PlatformDistribution() {
+  const { selectedBrand } = useAppStore();
+  const data = platformData[selectedBrand || 'brand1'] || [];
   return (
     <motion.div
       initial={{ opacity: 0, y: 20 }}
@@ -23,7 +26,7 @@ export function PlatformDistribution() {
           <ResponsiveContainer width="100%" height={280}>
             <PieChart>
               <Pie
-                data={platformData}
+                data={data}
                 cx="50%"
                 cy="50%"
                 innerRadius={60}
@@ -31,7 +34,7 @@ export function PlatformDistribution() {
                 paddingAngle={5}
                 dataKey="mentions"
               >
-                {platformData.map((entry, index) => (
+                {data.map((entry, index) => (
                   <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
                 ))}
               </Pie>

--- a/components/dashboard/mentions-feed.tsx
+++ b/components/dashboard/mentions-feed.tsx
@@ -34,7 +34,12 @@ const platformColors = {
 };
 
 export function MentionsFeed() {
-  const { mentions } = useAppStore();
+  const { mentions, selectedBrand } = useAppStore();
+  const filtered = React.useMemo(
+    () =>
+      mentions.filter((m) => !selectedBrand || m.brandId === selectedBrand),
+    [mentions, selectedBrand]
+  );
   return (
     <Card className="h-[600px]">
       <CardHeader>
@@ -48,7 +53,7 @@ export function MentionsFeed() {
       <CardContent>
         <ScrollArea className="h-[500px] pr-4">
           <div className="space-y-4">
-            {mentions.map((mention, index) => {
+            {filtered.map((mention, index) => {
               const PlatformIcon = platformIcons[mention.platform];
               const platformColor = platformColors[mention.platform];
               

--- a/components/pages/dashboard.tsx
+++ b/components/pages/dashboard.tsx
@@ -6,8 +6,11 @@ import { KPICards } from '@/components/dashboard/kpi-cards';
 import { MentionsFeed } from '@/components/dashboard/mentions-feed';
 import { MentionVolumeChart } from '@/components/dashboard/charts/mention-volume-chart';
 import { PlatformDistribution } from '@/components/dashboard/charts/platform-distribution';
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
+import { useAppStore } from '@/lib/store';
 
 export function Dashboard() {
+  const { brands, selectedBrand, setSelectedBrand } = useAppStore();
   return (
     <div className="p-6 space-y-6">
       {/* Header */}
@@ -23,6 +26,21 @@ export function Dashboard() {
           insights across all your monitored brands and products
         </p>
       </motion.div>
+
+      <div className="max-w-xs">
+        <Select value={selectedBrand ?? ''} onValueChange={setSelectedBrand}>
+          <SelectTrigger>
+            <SelectValue placeholder="Select Campaign" />
+          </SelectTrigger>
+          <SelectContent>
+            {brands.map((b) => (
+              <SelectItem key={b.id} value={b.id}>
+                {b.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
 
       {/* KPI Cards */}
       <KPICards />

--- a/components/pages/reports.tsx
+++ b/components/pages/reports.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import React from 'react';
+import { useAppStore } from '@/lib/store';
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from '@/components/ui/table';
+
+export function Reports() {
+  const { brands, selectedBrand, setSelectedBrand } = useAppStore();
+  const reports = [
+    { id: 'r1', name: 'Weekly Summary', date: '2024-01-01', brandId: 'brand1' },
+    { id: 'r2', name: 'Engagement Overview', date: '2024-01-02', brandId: 'brand2' },
+  ].filter((r) => !selectedBrand || r.brandId === selectedBrand);
+
+  return (
+    <div className="p-6 space-y-6">
+      <h1 className="text-3xl font-bold">Reports</h1>
+      <div className="max-w-xs">
+        <Select value={selectedBrand ?? ''} onValueChange={setSelectedBrand}>
+          <SelectTrigger>
+            <SelectValue placeholder="Select Campaign" />
+          </SelectTrigger>
+          <SelectContent>
+            {brands.map((b) => (
+              <SelectItem key={b.id} value={b.id}>
+                {b.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Name</TableHead>
+            <TableHead>Date</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {reports.map((r) => (
+            <TableRow key={r.id}>
+              <TableCell>{r.name}</TableCell>
+              <TableCell>{r.date}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/lib/sample-data.ts
+++ b/lib/sample-data.ts
@@ -1,18 +1,161 @@
-import { Brand, Mention, Product, KPICard, ChartData, GeoData, PlatformData } from './types';
+import { Brand, Mention, KPICard, ChartData, PlatformData } from './types';
 
-// Empty placeholder datasets used during development. These will be populated via webhooks.
-export const sampleBrands: Brand[] = [];
-export const sampleProducts: Product[] = [];
-export const sampleMentions: Mention[] = [];
-export const sampleKPIs: KPICard[] = [];
-export const platformData: PlatformData[] = [];
-export const geoData: GeoData[] = [];
+export const sampleBrands: Brand[] = [
+  {
+    id: 'brand1',
+    name: 'Acme Corp',
+    company: 'Acme Corp',
+    logo: '',
+    industry: 'Technology',
+    keywords: ['acme', 'tech'],
+    hashtags: ['acme', 'tech'],
+    socialHandles: {
+      twitter: '@acme',
+      instagram: 'acme',
+      facebook: 'acme',
+      linkedin: 'acme',
+      tiktok: 'acme',
+      youtube: 'acme',
+      reddit: 'acme',
+      news: 'acme',
+    },
+    targetCountries: ['United States'],
+    languages: ['English'],
+    status: 'active',
+    totalMentions: 1200,
+    sentiment: 0.7,
+    weeklyChange: 5,
+    lastUpdate: new Date().toISOString(),
+  },
+  {
+    id: 'brand2',
+    name: 'Globex',
+    company: 'Globex Corp',
+    logo: '',
+    industry: 'Finance',
+    keywords: ['globex'],
+    hashtags: ['globex'],
+    socialHandles: {
+      twitter: '@globex',
+      instagram: 'globex',
+      facebook: 'globex',
+      linkedin: 'globex',
+      tiktok: 'globex',
+      youtube: 'globex',
+      reddit: 'globex',
+      news: 'globex',
+    },
+    targetCountries: ['United States'],
+    languages: ['English'],
+    status: 'active',
+    totalMentions: 900,
+    sentiment: 0.6,
+    weeklyChange: -2,
+    lastUpdate: new Date().toISOString(),
+  },
+];
 
-export const generateTimeSeriesData = (days: number = 30): ChartData[] => [];
+export const sampleMentions: Mention[] = [
+  {
+    id: 'm1',
+    brandId: 'brand1',
+    platform: 'twitter',
+    user: {
+      id: 'u1',
+      name: 'John Doe',
+      handle: '@johndoe',
+      avatar: 'JD',
+      verified: false,
+      followers: 200,
+      userType: 'customer',
+    },
+    content: 'Love the new Acme product! #acme',
+    sentiment: 0.8,
+    sentimentLabel: 'positive',
+    engagement: { likes: 10, shares: 2, comments: 1 },
+    timestamp: new Date().toISOString(),
+    location: 'USA',
+    keywords: ['acme'],
+    url: 'https://twitter.com',
+    reach: 100,
+  },
+  {
+    id: 'm2',
+    brandId: 'brand1',
+    platform: 'facebook',
+    user: {
+      id: 'u2',
+      name: 'Jane Roe',
+      handle: '@janeroe',
+      avatar: 'JR',
+      verified: true,
+      followers: 500,
+      userType: 'influencer',
+    },
+    content: 'Not impressed with Acme this year.',
+    sentiment: 0.2,
+    sentimentLabel: 'negative',
+    engagement: { likes: 3, shares: 1, comments: 2 },
+    timestamp: new Date().toISOString(),
+    location: 'USA',
+    keywords: ['acme'],
+    url: 'https://facebook.com',
+    reach: 200,
+  },
+  {
+    id: 'm3',
+    brandId: 'brand2',
+    platform: 'twitter',
+    user: {
+      id: 'u3',
+      name: 'Alice',
+      handle: '@alice',
+      avatar: 'A',
+      verified: false,
+      followers: 150,
+      userType: 'customer',
+    },
+    content: 'Globex services are outstanding!',
+    sentiment: 0.9,
+    sentimentLabel: 'positive',
+    engagement: { likes: 8, shares: 1, comments: 1 },
+    timestamp: new Date().toISOString(),
+    location: 'UK',
+    keywords: ['globex'],
+    url: 'https://twitter.com',
+    reach: 120,
+  },
+];
 
-export const productIntelligenceData = {
-  mentionVolume: [] as ChartData[],
-  sentimentTrend: [] as ChartData[],
-  featureAnalysis: [] as { feature: string; mentions: number; sentiment: number; trend: string }[],
-  customerJourney: [] as { stage: string; mentions: number; conversion: number }[],
+export const platformData: Record<string, PlatformData[]> = {
+  brand1: [
+    { platform: 'twitter', mentions: 60, engagement: 70, sentiment: 0.7, color: '#1DA1F2' },
+    { platform: 'facebook', mentions: 40, engagement: 30, sentiment: 0.6, color: '#1877F2' },
+  ],
+  brand2: [
+    { platform: 'twitter', mentions: 50, engagement: 60, sentiment: 0.8, color: '#1DA1F2' },
+    { platform: 'instagram', mentions: 30, engagement: 40, sentiment: 0.7, color: '#E4405F' },
+  ],
+};
+
+export const sampleKPIs: KPICard[] = [
+  { title: 'Total Mentions', value: '1.2k', change: '+5%', trend: 'up', sparklineData: [10,20,30,40], color: 'blue' },
+  { title: 'Engagement', value: '300', change: '-3%', trend: 'down', sparklineData: [40,30,20,10], color: 'red' },
+];
+
+export const generateTimeSeriesData = (brandId: string, days: number = 30): ChartData[] => {
+  const data: ChartData[] = [];
+  for (let i = days - 1; i >= 0; i--) {
+    const date = new Date();
+    date.setDate(date.getDate() - i);
+    const base = brandId === 'brand1' ? 100 : 80;
+    data.push({
+      date: date.toISOString().split('T')[0],
+      total: base + Math.round(Math.random() * 20),
+      positive: Math.round(Math.random() * 40),
+      neutral: Math.round(Math.random() * 30),
+      negative: Math.round(Math.random() * 20),
+    });
+  }
+  return data;
 };

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { Brand, Mention, Product } from './types';
+import { sampleBrands, sampleMentions } from './sample-data';
 
 interface AppState {
 
@@ -47,11 +48,11 @@ export const useAppStore = create<AppState>((set, get) => ({
   sidebarCollapsed: false,
   darkMode: false,
   currentPage: 'dashboard',
-  selectedBrand: null,
+  selectedBrand: 'brand1',
   selectedProduct: null,
 
-  brands: [],
-  mentions: [],
+  brands: sampleBrands,
+  mentions: sampleMentions,
   products: [],
 
   

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -12,6 +12,7 @@ export interface User {
 
 export interface Mention {
   id: string;
+  brandId: string;
   platform: Platform;
   user: User;
   content: string;


### PR DESCRIPTION
## Summary
- seed brands and mentions with sample data
- extend `Mention` type with `brandId`
- initialize store with sample data
- filter dashboard charts and feeds by selected campaign
- add campaign selector to dashboard
- implement basic Reports page with campaign selector

## Testing
- `npm run build` *(fails: next not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68531e67286083278caaf0be7c1cb968