### PR TITLE
Fix hydration error for relative timestamps

### DIFF
--- a/components/dashboard/mentions-feed.tsx
+++ b/components/dashboard/mentions-feed.tsx
@@ -9,7 +9,7 @@ import { Badge } from '@/components/ui/badge';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { useAppStore } from '@/lib/store';
-import { formatDistanceToNow } from 'date-fns';
+import { TimeAgo } from '@/components/ui/time-ago';
 
 const platformIcons = {
   twitter: Twitter,
@@ -121,9 +121,7 @@ export function MentionsFeed() {
                         </div>
                         
                         <div className="flex items-center space-x-2">
-                          <span className="text-xs text-gray-500">
-                            {formatDistanceToNow(new Date(mention.timestamp), { addSuffix: true })}
-                          </span>
+                          <TimeAgo date={mention.timestamp} className="text-xs text-gray-500" />
                           <Button variant="ghost" size="sm" className="h-8 w-8 p-0">
                             <ExternalLink className="w-3 h-3" />
                           </Button>

--- a/components/ui/time-ago.tsx
+++ b/components/ui/time-ago.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import React from 'react';
+import { formatDistanceToNow } from 'date-fns';
+
+interface TimeAgoProps {
+  date: Date | string;
+  className?: string;
+}
+
+export function TimeAgo({ date, className }: TimeAgoProps) {
+  const [text, setText] = React.useState('');
+
+  React.useEffect(() => {
+    const target = typeof date === 'string' ? new Date(date) : date;
+    function update() {
+      setText(formatDistanceToNow(target, { addSuffix: true }));
+    }
+    update();
+    const id = setInterval(update, 60000);
+    return () => clearInterval(id);
+  }, [date]);
+
+  return (
+    <span suppressHydrationWarning className={className}>{text}</span>
+  );
+}


### PR DESCRIPTION
## Summary
- add `TimeAgo` client component for dynamic relative timestamps
- use `TimeAgo` in mentions feed to avoid server/client mismatch

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_685329fc90e88327be1ea450a4404359