### PR TITLE
Add n8n webhook integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_N8N_WEBHOOK_URL=https://example.com/webhook
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 # sb1-dtfebxye
 
 [Edit in StackBlitz next generation editor ⚡️](https://stackblitz.com/~/github.com/abdelrahmanelsayyad/sb1-dtfebxye)
+
+## Environment
+
+Create a `.env.local` file with your n8n webhook URL:
+
+```bash
+NEXT_PUBLIC_N8N_WEBHOOK_URL=https://your-n8n-instance/webhook
+```
+
+This value is used when launching a social listening campaign.

--- a/components/pages/campaign-setup.tsx
+++ b/components/pages/campaign-setup.tsx
@@ -146,6 +146,28 @@ export function CampaignSetup() {
     }
   };
 
+  const launchCampaign = async () => {
+    console.log('Launching campaign with data:', formData);
+    const webhookUrl = process.env.NEXT_PUBLIC_N8N_WEBHOOK_URL;
+    if (!webhookUrl) {
+      console.error('N8N webhook URL is not defined');
+      return;
+    }
+    try {
+      const res = await fetch(webhookUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(formData),
+      });
+      const data = await res.json().catch(() => null);
+      console.log('n8n webhook response:', data);
+    } catch (error) {
+      console.error('Error sending data to n8n webhook:', error);
+    }
+  };
+
   const progress = (currentStep / steps.length) * 100;
 
   const renderStepContent = () => {
@@ -912,11 +934,7 @@ export function CampaignSetup() {
               </Button>
             ) : (
               <Button
-                onClick={() => {
-                  // Handle campaign launch
-                  console.log('Launching campaign with data:', formData);
-                  // You would typically send this data to your backend here
-                }}
+                onClick={launchCampaign}
                 className="flex items-center space-x-2 bg-green-600 hover:bg-green-700 text-white px-8 py-3 text-lg"
               >
                 <Zap className="w-5 h-5" />


### PR DESCRIPTION
## Summary
- post campaign form data to an n8n webhook
- document environment variable for the webhook
- provide `.env.example` with example webhook URL

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853540dd7d88327b8ebcd33361f80a7