### PR TITLE
Embed n8n webhook URL in source

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
-NEXT_PUBLIC_N8N_WEBHOOK_URL=https://n8n.srv872107.hstgr.cloud/webhook/8d7fd1cb-4b17-409b-b890-73fb176a1673
+# No environment variables are required.
+# The n8n webhook URL is hardcoded in the application.
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,12 @@
 
 ## Environment
 
-Create a `.env.local` file with your n8n webhook URL:
+No environment variables are required for the n8n integration. The webhook URL
+is embedded directly in the code:
 
-```bash
-NEXT_PUBLIC_N8N_WEBHOOK_URL=https://n8n.srv872107.hstgr.cloud/webhook/8d7fd1cb-4b17-409b-b890-73fb176a1673
+```
+https://n8n.srv872107.hstgr.cloud/webhook/8d7fd1cb-4b17-409b-b890-73fb176a1673
 ```
 
-This value is used when launching a social listening campaign.
+All campaign details are posted to this endpoint when a user launches a social
+listening campaign.

--- a/components/pages/campaign-setup.tsx
+++ b/components/pages/campaign-setup.tsx
@@ -146,18 +146,13 @@ export function CampaignSetup() {
     }
   };
 
+  const WEBHOOK_URL = 'https://n8n.srv872107.hstgr.cloud/webhook/8d7fd1cb-4b17-409b-b890-73fb176a1673';
+
   const launchCampaign = async () => {
     console.log('Launching campaign with data:', formData);
-    
-    const webhookUrl = process.env.NEXT_PUBLIC_N8N_WEBHOOK_URL;
-    
-    if (!webhookUrl) {
-      console.error('N8N webhook URL not configured. Please set NEXT_PUBLIC_N8N_WEBHOOK_URL in your environment variables.');
-      return;
-    }
-    
+
     try {
-      const res = await fetch(webhookUrl, {
+      const res = await fetch(WEBHOOK_URL, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- embed n8n webhook URL directly in `CampaignSetup` component
- clarify in README that no environment variables are needed
- update `.env.example` to reflect the change

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68536b9970848327a7f418a6481be193