### PR TITLE
Fix webhook sending

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
-# No environment variables are required.
-# The n8n webhook URL is hardcoded in the application.
+# URL of the n8n webhook to receive campaign data
+N8N_WEBHOOK_URL=https://n8n.srv872107.hstgr.cloud/webhook/8d7fd1cb-4b17-409b-b890-73fb176a1673
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 ## Environment
 
-No environment variables are required for the n8n integration. The webhook URL
-is embedded directly in the code:
+Set the `N8N_WEBHOOK_URL` environment variable to the URL of your n8n webhook.
+An example value is included in `.env.example`:
 
-```
-https://n8n.srv872107.hstgr.cloud/webhook/8d7fd1cb-4b17-409b-b890-73fb176a1673
+```env
+N8N_WEBHOOK_URL=https://n8n.srv872107.hstgr.cloud/webhook/8d7fd1cb-4b17-409b-b890-73fb176a1673
 ```
 
 All campaign details are posted to this endpoint when a user launches a social

--- a/app/api/launch-campaign/route.ts
+++ b/app/api/launch-campaign/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const webhookUrl = process.env.N8N_WEBHOOK_URL;
+    if (!webhookUrl) {
+      console.error('N8N_WEBHOOK_URL is not defined');
+      return NextResponse.json({ ok: false, error: 'Webhook URL not configured' }, { status: 500 });
+    }
+
+    const res = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
+    const data = await res.json().catch(() => null);
+
+    return NextResponse.json({ ok: true, data });
+  } catch (error) {
+    console.error('Error forwarding to n8n webhook:', error);
+    return NextResponse.json({ ok: false, error: 'Failed to forward request' }, { status: 500 });
+  }
+}

--- a/components/pages/campaign-setup.tsx
+++ b/components/pages/campaign-setup.tsx
@@ -146,13 +146,11 @@ export function CampaignSetup() {
     }
   };
 
-  const WEBHOOK_URL = 'https://n8n.srv872107.hstgr.cloud/webhook/8d7fd1cb-4b17-409b-b890-73fb176a1673';
-
   const launchCampaign = async () => {
     console.log('Launching campaign with data:', formData);
 
     try {
-      const res = await fetch(WEBHOOK_URL, {
+      const res = await fetch('/api/launch-campaign', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- add a server API route to proxy campaign data to n8n
- read webhook URL from `N8N_WEBHOOK_URL` environment variable
- document the new environment variable
- send launch requests to the new API route

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68536d2400cc8327b018d3b5244cc834